### PR TITLE
Wan12 (#587)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,6 @@ Features
 - (:issue:`475`) Support for WebAuthn
 - (:pr:`532`) Support for Python 3.10
 - (:pr:`540`) Improve Templates in support of JS required by WebAuthn
-- (:pr:`xxx`) Make roles joinedload compatible with SQLAlchemy 2.0
 - (:pr:`568`) Deprecate the old passwordless feature in favor of Unified Signin.
    Deprecate replacing login_manager so we can possibly vendor that in in the future.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -217,6 +217,7 @@ Forms
 .. autoclass:: flask_security.SendConfirmationForm
 .. autoclass:: flask_security.TwoFactorVerifyCodeForm
 .. autoclass:: flask_security.TwoFactorSetupForm
+.. autoclass:: flask_security.TwoFactorSelectForm
 .. autoclass:: flask_security.TwoFactorRescueForm
 .. autoclass:: flask_security.UnifiedSigninForm
 .. autoclass:: flask_security.UnifiedSigninSetupForm

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1084,6 +1084,24 @@ Configuration related to the two-factor authentication feature.
 
     Default: ``"/tf-rescue"``.
 
+.. py:data:: SECURITY_TWO_FACTOR_SELECT_URL
+
+    Specifies the two factor select URL. This is used when the user has
+    setup more than one second factor.
+
+    Default: ``"/tf-select"``.
+
+    .. versionadded:: 4.2.0
+
+
+.. py:data:: SECURITY_TWO_FACTOR_SELECT_TEMPLATE
+
+    Specifies the path to the template for the select method page for the two-factor authentication process.
+
+    Default: ``security/two_factor_select.html``.
+
+    .. versionadded:: 4.2.0
+
 .. py:data:: SECURITY_TWO_FACTOR_ALWAYS_VALIDATE
 
     Specifies whether the application should require a two factor code upon every login.
@@ -1105,6 +1123,15 @@ Configuration related to the two-factor authentication feature.
     The complete set of parameters is described in Flask's `set_cookie`_ documentation.
 
     Default: ``{'httponly': True, 'secure': False, 'samesite': None}``.
+
+.. py:data:: SECURITY_TWO_FACTOR_IMPLEMENTATIONS
+
+    A dictionary of supported second factor implementations. All of these must
+    implement the TfPluginBase interface.
+
+    Default: ``{"code": "flask_security.twofactor.CodeTfPlugin", "webauthn": "flask_security.webauthn.WebAuthnTfPlugin",}``
+
+    .. versionadded:: 4.2.0
 
 
 Unified Signin
@@ -1423,7 +1450,9 @@ WebAuthn
         - ``"secondary"`` - just keys registered as "secondary" are allowed
 
     If list is empty or ``None`` WebAuthn keys aren't allowed. This also means that the
-            :py:data::``SECURITY_WAN_VERIFY`` endpoint won't be registered.
+            :py:data:``SECURITY_WAN_VERIFY`` endpoint won't be registered.
+
+    Default:: ``["first", "secondary"]``
 
 
 

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -22,6 +22,7 @@ following is a list of view templates:
 * `security/send_confirmation.html`
 * `security/send_login.html`
 * `security/verify.html`
+* `security/two_factor_select.html`
 * `security/two_factor_setup.html`
 * `security/two_factor_verify_code.html`
 * `security/us_signin.html`
@@ -70,6 +71,7 @@ The following is a list of all the available context processor decorators:
 * ``send_confirmation_context_processor``: Send confirmation view
 * ``send_login_context_processor``: Send login view
 * ``mail_context_processor``: Whenever an email will be sent
+* ``tf_select_context_processor``: Two factor select view
 * ``tf_setup_context_processor``: Two factor setup view
 * ``tf_token_validation_context_processor``: Two factor token validation view
 * ``us_signin_context_processor``: Unified sign in view
@@ -120,6 +122,7 @@ The following is a list of all the available form overrides:
 * ``send_confirmation_form``: Send confirmation form
 * ``passwordless_login_form``: Passwordless login form
 * ``two_factor_verify_code_form``: Two-factor verify code form
+* ``two_factor_select_form``: Two-factor select form
 * ``two_factor_setup_form``: Two-factor setup form
 * ``two_factor_rescue_form``: Two-factor help user form
 * ``us_signin_form``: Unified sign in form

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -6,7 +6,7 @@
     security via Flask-Login, Flask-Principal, Flask-WTF, and passlib.
 
     :copyright: (c) 2012-2019 by Matt Wright.
-    :copyright: (c) 2019-2021 by J. Christopher Wagner.
+    :copyright: (c) 2019-2022 by J. Christopher Wagner.
     :license: MIT, see LICENSE for more details.
 """
 
@@ -79,6 +79,7 @@ from .signals import (
 )
 from .totp import Totp
 from .twofactor import tf_send_security_token
+from .tf_plugin import TwoFactorSelectForm
 from .unified_signin import (
     UnifiedSigninForm,
     UnifiedSigninSetupForm,

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -176,6 +176,10 @@ def get_form_field_label(key):
     return make_lazy_string(_local_xlate, _default_field_labels.get(key, ""))
 
 
+def get_form_field_xlate(txt):
+    return make_lazy_string(_local_xlate, txt)
+
+
 def unique_user_email(form, field):
     uia_email = get_identity_attribute("email")
     norm_email = _security._mail_util.normalize(field.data)

--- a/flask_security/templates/security/two_factor_select.html
+++ b/flask_security/templates/security/two_factor_select.html
@@ -1,0 +1,13 @@
+{% extends "security/base.html" %}
+{% from "security/_macros.html" import render_field_with_errors, render_field %}
+
+{% block content %}
+{% include "security/_messages.html" %}
+<h1>{{ _fsdomain('Select Two Factor Method') }}</h1>
+<form action="{{ url_for_security("tf_select") }}" method="POST" name="tf_select">
+  {{ two_factor_select_form.hidden_tag() }}
+  {{ render_field_with_errors(two_factor_select_form.which) }}
+  {{ render_field(two_factor_select_form.submit) }}
+</form>
+{% include "security/_menu.html" %}
+{% endblock %}

--- a/flask_security/templates/security/two_factor_verify_code.html
+++ b/flask_security/templates/security/two_factor_verify_code.html
@@ -4,34 +4,23 @@
 {% block content %}
     {% include "security/_messages.html" %}
     <h1>{{ _fsdomain("Two-factor Authentication") }}</h1>
-    {% if chosen_method %}
-      <h2>{{ _fsdomain("Please enter your authentication code generated via: %(method)s", method=chosen_method) }}</h2>
-      <form action="{{ url_for_security("two_factor_token_validation") }}" method="POST"
-            name="two_factor_verify_code_form">
-          {{ two_factor_verify_code_form.hidden_tag() }}
-          {{ render_field_with_errors(two_factor_verify_code_form.code, placeholder="enter code") }}
-          {{ render_field(two_factor_verify_code_form.submit) }}
-      </form>
-      <form action="{{ url_for_security("two_factor_rescue") }}" method="POST" name="two_factor_rescue_form">
-          {{ two_factor_rescue_form.hidden_tag() }}
-          {{ render_field_with_errors(two_factor_rescue_form.help_setup) }}
-          {% if problem=="lost_device" %}
-              <div>{{ _fsdomain("The code for authentication was sent to your email address") }}</div>
-          {% endif %}
-          {% if problem=="no_mail_access" %}
-              <div>{{ _fsdomain("A mail was sent to us in order to reset your application account") }}</div>
-          {% endif %}
-          {{ render_field(two_factor_rescue_form.submit) }}
-      </form>
-    {% endif %}
-    {% if has_webauthn %}
-      <h2>{{ _fsdomain("Use a registered WebAuthn security key") }}</h2>
-      <form action="{{ url_for_security("wan_signin") }}" method="POST"
-            name="wan_signin_form">
-        {{ wan_signin_form.hidden_tag() }}
-        {{ render_field_with_errors(wan_signin_form.identity) }}
-        {{ render_field(wan_signin_form.submit, value="Authenticate") }}
-      </form>
-    {% endif %}
+    <h2>{{ _fsdomain("Please enter your authentication code generated via: %(method)s", method=chosen_method) }}</h2>
+    <form action="{{ url_for_security("two_factor_token_validation") }}" method="POST"
+          name="two_factor_verify_code_form">
+        {{ two_factor_verify_code_form.hidden_tag() }}
+        {{ render_field_with_errors(two_factor_verify_code_form.code, placeholder="enter code") }}
+        {{ render_field(two_factor_verify_code_form.submit) }}
+    </form>
+    <form action="{{ url_for_security("two_factor_rescue") }}" method="POST" name="two_factor_rescue_form">
+        {{ two_factor_rescue_form.hidden_tag() }}
+        {{ render_field_with_errors(two_factor_rescue_form.help_setup) }}
+        {% if problem=="lost_device" %}
+            <div>{{ _fsdomain("The code for authentication was sent to your email address") }}</div>
+        {% endif %}
+        {% if problem=="no_mail_access" %}
+            <div>{{ _fsdomain("A mail was sent to us in order to reset your application account") }}</div>
+        {% endif %}
+        {{ render_field(two_factor_rescue_form.submit) }}
+    </form>
     {% include "security/_menu.html" %}
 {% endblock %}

--- a/flask_security/templates/security/us_setup.html
+++ b/flask_security/templates/security/us_setup.html
@@ -30,13 +30,13 @@
           name="us_setup_form">
       {{ us_setup_form.hidden_tag() }}
       {% if setup_methods %}
-        <div class="fs-div">Currently active sign in options:
+        <div class="fs-div">Currently active sign in options:<em>
         {% if active_methods %}
           {{ ", ".join(active_methods) }}
         {% else %}
           None.
         {% endif %}
-        </div>
+        </em></div>
 
         <h3>{{ _fsdomain("Setup additional sign in option") }}</h3>
         <div class="fs-div">

--- a/flask_security/templates/security/wan_signin.html
+++ b/flask_security/templates/security/wan_signin.html
@@ -14,13 +14,19 @@
 
 {% block content %}
   {% include "security/_messages.html" %}
-  <h1>{{ _fsdomain("Sign In Using WebAuthn Security Key") }}</h1>
+  {% if not is_secondary %}
+    <h1>{{ _fsdomain("Sign In Using WebAuthn Security Key") }}</h1>
+  {% else %}
+    <h1>{{ _fsdomain("Use Your WebAuthn Security Key as a Second Factor") }}</h1>
+  {% endif %}
   {% if not credential_options %}
     <form action="{{ url_for_security("wan_signin") }}" method="POST"
           name="wan_signin_form" id="wan-signin-form">
       {{ wan_signin_form.hidden_tag() }}
-      {{ render_field_with_errors(wan_signin_form.identity) }}
-      {{ render_field_with_errors(wan_signin_form.remember) }}
+      {% if not is_secondary %}
+        {{ render_field_with_errors(wan_signin_form.identity) }}
+        {{ render_field_with_errors(wan_signin_form.remember) }}
+      {% endif %}
       {{ render_field_errors(wan_signin_form.credential) }}
       {{ render_field(wan_signin_form.submit) }}
     </form>

--- a/flask_security/tf_plugin.py
+++ b/flask_security/tf_plugin.py
@@ -1,0 +1,323 @@
+"""
+    flask_security.tf_plugin
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Flask-Security Two-Factor Plugin Module
+
+    :copyright: (c) 2022-2022 by J. Christopher Wagner (jwag).
+    :license: MIT, see LICENSE for more details.
+
+    TODO:
+        - add localzed callback for select choices.
+"""
+import typing as t
+
+from flask import request, redirect, session
+from werkzeug.datastructures import MultiDict
+
+from .decorators import unauth_csrf
+from .forms import (
+    get_form_field_xlate,
+    Form,
+    RadioField,
+    SubmitField,
+)
+from .proxies import _datastore, _security
+from .utils import (
+    _,
+    base_render_json,
+    check_and_get_token_status,
+    config_value as cv,
+    do_flash,
+    get_message,
+    get_within_delta,
+    get_url,
+    json_error_response,
+    login_user,
+    simple_render_json,
+    suppress_form_csrf,
+    url_for_security,
+)
+
+if t.TYPE_CHECKING:  # pragma: no cover
+    import flask
+    from flask.typing import ResponseValue
+    from flask import Response
+    from .core import Security
+    from .datastore import User
+
+
+class TwoFactorSelectForm(Form):
+    which = RadioField(get_form_field_xlate(_("Available Second Factor Methods:")))
+    submit = SubmitField(get_form_field_xlate(_("Select")))
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+
+@unauth_csrf(fall_through=True)
+def tf_select() -> "ResponseValue":
+    # Ask user which MFA method they want to use.
+    # This is used when a user has setup more than one type of 2FA.
+    form_class = _security.two_factor_select_form
+    if request.is_json:
+        form = form_class(MultiDict(request.get_json()), meta=suppress_form_csrf())
+    else:
+        form = form_class(meta=suppress_form_csrf())
+
+    # This endpoint is unauthenticated - make sure we're in a valid state
+    if not all(k in session for k in ["tf_user_id", "tf_select"]):
+        # illegal call on this endpoint
+        tf_clean_session()
+        return tf_illegal_state(form, _security.login_url)
+
+    user = _datastore.find_user(fs_uniquifier=session["tf_user_id"])
+    if not user:  # pragma no cover
+        # hard to imagine - someone deletes the user while they are logging in.
+        tf_clean_session()
+        return tf_illegal_state(form, _security.login_url)
+
+    setup_methods = _security.two_factor_plugins.get_setup_tf_methods(user)
+    form.which.choices = setup_methods
+
+    if form.validate_on_submit():
+        response = None
+        tf_impl = _security.two_factor_plugins.method_to_impl(user, form.which.data)
+        if tf_impl:
+            json_payload = {"tf_required": True}
+            response = tf_impl.tf_login(user, json_payload)
+        if not response:  # pragma no cover
+            # This really can't happen unless between the time the started logging in
+            # and now, they deleted a second factor (which they would have to do
+            # in another window).
+            tf_clean_session()
+            return tf_illegal_state(form, _security.login_url)
+        return response
+
+    if _security._want_json(request):
+        payload = {"tf_select": True, "tf_setup_methods": setup_methods}
+        return base_render_json(form, include_user=False, additional=payload)
+
+    return _security.render_template(
+        cv("TWO_FACTOR_SELECT_TEMPLATE"),
+        two_factor_select_form=form,
+        **_security._run_ctx_processor("tf_select"),
+    )
+
+
+class TfPluginBase:  # pragma no cover
+    def __init__(self, app: "flask.Flask"):
+        pass
+
+    def create_blueprint(
+        self, app: "flask.Flask", bp: "flask.Blueprint", state: "Security"
+    ) -> None:
+        raise NotImplementedError
+
+    def get_setup_methods(self, user: "User") -> t.List[t.Optional[str]]:
+        # Return a list of methods that ``user`` has setup for this second factor
+        raise NotImplementedError
+
+    def tf_login(
+        self, user: "User", json_payload: t.Dict[str, t.Any]
+    ) -> "ResponseValue":
+        raise NotImplementedError
+
+
+class TfPlugin:
+    """
+    Two-Factor plugin support.
+
+    Enables multiple independent two-factor implementations to be configured for a given
+    app. See TfPluginBase for what a new implementation must provide.
+    """
+
+    def __init__(self):
+        self._tf_impls: t.Dict[str, "TfPluginBase"] = {}
+
+    def register_tf_impl(
+        # N.B. all methods must be unique across all implementations.
+        self,
+        app: "flask.Flask",
+        name: str,
+        impl: t.Type["TfPluginBase"],
+    ) -> None:
+        self._tf_impls[name] = impl(app)
+
+    def create_blueprint(
+        self, app: "flask.Flask", bp: "flask.Blueprint", state: "Security"
+    ) -> None:
+        if cv("TWO_FACTOR", app):
+            for impl in self._tf_impls.values():
+                impl.create_blueprint(app, bp, state)
+            # Add our route for selecting between multiple active two-factor
+            # mechanisms.
+            bp.route(
+                cv("TWO_FACTOR_SELECT_URL", app),
+                methods=["GET", "POST"],
+                endpoint="tf_select",
+            )(tf_select)
+
+    def method_to_impl(self, user: "User", method: str) -> t.Optional[TfPluginBase]:
+        # reverse map a method to the implementation.
+        # N.B. again - requires that methods be unique across all implementations.
+        # There is a small window that a previously setup method was removed.
+        for impl in self._tf_impls.values():
+            setup_methods = impl.get_setup_methods(user)
+            if method in setup_methods:
+                return impl
+        return None  # pragma no cover
+
+    def get_setup_tf_methods(self, user: "User") -> t.List[t.Optional[str]]:
+        # Return list of methods that user has setup
+        methods = []
+        for impl in self._tf_impls.values():
+            methods.extend(impl.get_setup_methods(user))
+        return methods
+
+    def tf_enter(
+        self, user: "User", remember_me: bool, primary_authn_via: str
+    ) -> t.Optional["ResponseValue"]:
+        """Check if two-factor is required and if so, start the process.
+        Must be called in a request context.
+        remember_me controls 2 cookies - the remember_me cookie and the tf_validity
+        cookie. We use the session to hold the fact that the user requested 'remember'
+        across the second factor.
+        """
+        json_payload: t.Dict[str, t.Any]
+        if cv("TWO_FACTOR"):
+            tf_setup_methods = self.get_setup_tf_methods(user)
+            if cv("TWO_FACTOR_REQUIRED") or len(tf_setup_methods) > 0:
+                tf_fresh = tf_verify_validity_token(user.fs_uniquifier)
+                if cv("TWO_FACTOR_ALWAYS_VALIDATE") or not tf_fresh:
+                    # Clean out any potential old session info - in case of previous
+                    # aborted 2FA attempt.
+                    tf_clean_session()
+
+                    json_payload = {"tf_required": True}
+                    if remember_me:
+                        session["tf_remember_login"] = remember_me
+
+                    session["tf_user_id"] = user.fs_uniquifier
+                    # A backwards compat hack - the original twofactor could be setup
+                    # as part of initial login.
+                    if len(tf_setup_methods) == 0:
+                        # only initial two-factor implementation supports this
+                        return self._tf_impls["code"].tf_login(user, json_payload)
+                    elif len(tf_setup_methods) == 1:
+                        # method_to_impl can't return None here since we just
+                        # got the methods up above.
+                        impl = t.cast(
+                            TfPluginBase,
+                            self.method_to_impl(user, t.cast(str, tf_setup_methods[0])),
+                        )
+                        return impl.tf_login(user, json_payload)
+                    else:
+                        session["tf_select"] = True
+                        if not _security._want_json(request):
+                            return redirect(url_for_security("tf_select"))
+                        # Lets force app to go through tf-select just in case we want
+                        # to do further validation... However provide the choices
+                        # so they can just to a POST
+                        json_payload.update(
+                            {
+                                "tf_select": True,
+                                "tf_setup_methods": tf_setup_methods,
+                            }
+                        )
+                        return simple_render_json(json_payload)
+        return None
+
+    def tf_complete(self, user: "User", dologin: bool) -> t.Optional[str]:
+        remember = session.pop("tf_remember_login", None)
+
+        if dologin:
+            login_user(user, remember=remember)
+        tf_clean_session()
+        token = None
+        # return a token to avoid future two-factor prompts (for a period of time)
+        if not cv("TWO_FACTOR_ALWAYS_VALIDATE") and remember:
+            token = generate_tf_validity_token(user.fs_uniquifier)
+        return token
+
+
+def generate_tf_validity_token(fs_uniquifier):
+    """Generates a unique token for the specified user.
+
+    :param fs_uniquifier: The fs_uniquifier of a user to whom the token belongs to
+    """
+    return _security.tf_validity_serializer.dumps(fs_uniquifier)
+
+
+def tf_validity_token_status(token):
+    """Returns the expired status, invalid status, and user of a
+    Two-Factor Validity token.
+    For example::
+
+        expired, invalid, user = tf_validity_token_status('...')
+
+    :param token: The Two-Factor Validity token
+    """
+    return check_and_get_token_status(
+        token, "tf_validity", get_within_delta("TWO_FACTOR_LOGIN_VALIDITY")
+    )
+
+
+def tf_verify_validity_token(fs_uniquifier: str) -> bool:
+    """Returns the status of the Two-Factor Validity token based on the current
+    request.
+
+    :param fs_uniquifier: The ``fs_uniquifier`` of the submitting user.
+    """
+    if request.is_json and request.content_length:
+        token = request.get_json().get("tf_validity_token", None)  # type: ignore
+    else:
+        token = request.cookies.get("tf_validity", default=None)
+
+    if token is None:
+        return False
+
+    expired, invalid, uniquifier = tf_validity_token_status(token)
+    if expired or invalid or (fs_uniquifier != uniquifier):
+        return False
+
+    return True
+
+
+def tf_set_validity_token_cookie(response: "Response", token: str) -> "Response":
+    """Sets the Two-Factor validity token for a specific user given that is
+    configured and the user selects remember me
+
+    :param response: The response with which to set the set_cookie
+    :param token: validity token
+    """
+    cookie_kwargs = cv("TWO_FACTOR_VALIDITY_COOKIE")
+    max_age = int(get_within_delta("TWO_FACTOR_LOGIN_VALIDITY").total_seconds())
+    response.set_cookie("tf_validity", value=token, max_age=max_age, **cookie_kwargs)
+
+    return response
+
+
+def tf_illegal_state(form, redirect_to):
+    m, c = get_message("TWO_FACTOR_PERMISSION_DENIED")
+    if not _security._want_json(request):
+        do_flash(m, c)
+        return redirect(get_url(redirect_to))
+    else:
+        return _security._render_json(json_error_response(m), 400, None, None)
+
+
+def tf_clean_session():
+    """
+    Clean out ALL stuff stored in session (e.g. on logout or restart of a session)
+    """
+    if cv("TWO_FACTOR"):
+        for k in [
+            "tf_state",
+            "tf_user_id",
+            "tf_primary_method",
+            "tf_remember_login",
+            "tf_totp_secret",
+            "tf_select",
+        ]:
+            session.pop(k, None)

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -43,11 +43,6 @@ from .forms import Form, Required, get_form_field_label
 from .proxies import _security, _datastore
 from .quart_compat import get_quart_status
 from .signals import us_profile_changed, us_security_token_sent
-from .twofactor import (
-    is_tf_setup,
-    tf_login,
-    tf_verify_validity_token,
-)
 from .utils import (
     _,
     SmsSenderFactory,
@@ -70,6 +65,7 @@ from .utils import (
     url_for_security,
     view_commit,
 )
+from .webauthn import has_webauthn
 
 if t.TYPE_CHECKING:  # pragma: no cover
     from flask.typing import ResponseValue
@@ -513,21 +509,15 @@ def us_signin() -> "ResponseValue":
 
     if form.validate_on_submit():
 
-        # Require multi-factor is it is enabled, and the method
-        # we authenticated with requires it and either user has requested MFA or it is
-        # required.
+        # Check if multi-factor is required. Some (this is configurable) don't
+        # need 2FA since they ARE multi-factor (such as SMS and authenticator).
         remember_me = form.remember.data if "remember" in form else None
-        if cv("TWO_FACTOR") and form.authn_via in cv("US_MFA_REQUIRED"):
-            tf_fresh = tf_verify_validity_token(form.user.fs_uniquifier)
-            if cv("TWO_FACTOR_REQUIRED") or is_tf_setup(form.user):
-                if cv("TWO_FACTOR_ALWAYS_VALIDATE") or (not tf_fresh):
-
-                    return tf_login(
-                        form.user,
-                        remember=remember_me,
-                        primary_authn_via=form.authn_via,
-                    )
-
+        if form.authn_via in cv("US_MFA_REQUIRED"):
+            response = _security.two_factor_plugins.tf_enter(
+                form.user, remember_me, form.authn_via
+            )
+            if response:
+                return response
         after_this_request(view_commit)
         login_user(form.user, remember=remember_me, authn_via=[form.authn_via])
 
@@ -600,8 +590,6 @@ def us_verify() -> "ResponseValue":
         return redirect(get_post_verify_redirect())
 
     # Here on GET or failed POST validate
-    from .webauthn import has_webauthn
-
     webauthn_available = has_webauthn(current_user, cv("WAN_ALLOW_AS_VERIFY"))
     if _security._want_json(request):
         payload = {
@@ -671,10 +659,11 @@ def us_verify_link() -> "ResponseValue":
         do_flash(m, c)
         return redirect(url_for_security("us_signin"))
 
+    tf_setup_methods = _security.two_factor_plugins.get_setup_tf_methods(user)
     if (
         cv("TWO_FACTOR")
         and "email" in cv("US_MFA_REQUIRED")
-        and (cv("TWO_FACTOR_REQUIRED") or is_tf_setup(user))
+        and (cv("TWO_FACTOR_REQUIRED") or len(tf_setup_methods) > 0)
     ):
         # tf_login doesn't know anything about "spa" etc. In general two-factor
         # isn't quite ready for SPA. So we return an error via a redirect rather
@@ -687,7 +676,9 @@ def us_verify_link() -> "ResponseValue":
                     qparams=user.get_redirect_qparams({"tf_required": 1}),
                 )
             )
-        return tf_login(user, primary_authn_via="email")
+        response = _security.two_factor_plugins.tf_enter(user, False, "email")
+        if response:
+            return response
 
     login_user(user, authn_via=["email"])
     after_this_request(view_commit)

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -1010,6 +1010,15 @@ def base_render_json(
     return _security._render_json(payload, code, None, user)
 
 
+def simple_render_json(
+    additional: t.Optional[t.Dict[str, t.Any]] = None,
+) -> "ResponseValue":
+    payload = dict(csrf_token=csrf.generate_csrf())
+    if additional:
+        payload.update(additional)
+    return _security._render_json(payload, 200, None, None)
+
+
 def default_want_json(req):
     """Return True if response should be in json
     N.B. do not call this directly - use security._want_json()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -369,6 +369,9 @@ def sqlalchemy_setup(request, app, tmpdir, realdburl):
     class Role(db.Model, fsqla.FsRoleMixin):
         pass
 
+    class WebAuthn(db.Model, fsqla.FsWebAuthnMixin):
+        pass
+
     class User(db.Model, fsqla.FsUserMixin):
         security_number = db.Column(db.Integer, unique=True)
         # For testing allow null passwords.
@@ -377,9 +380,6 @@ def sqlalchemy_setup(request, app, tmpdir, realdburl):
         def get_security_payload(self):
             # Make sure we still properly hook up to flask JSONEncoder
             return {"email": str(self.email), "last_update": self.update_datetime}
-
-    class WebAuthn(db.Model, fsqla.FsWebAuthnMixin):
-        pass
 
     with app.app_context():
         db.create_all()

--- a/tests/test_tf_plugin.py
+++ b/tests/test_tf_plugin.py
@@ -1,0 +1,122 @@
+"""
+    test_tf_plugin
+    ~~~~~~~~~~~~~~~~~
+
+    tf_plugin tests
+
+    :copyright: (c) 2022-2022 by J. Christopher Wagner (jwag).
+    :license: MIT, see LICENSE for more details.
+"""
+
+import json
+import pytest
+
+from tests.test_utils import (
+    SmsTestSender,
+    get_session,
+    get_existing_session,
+    logout,
+)
+from flask_security import (
+    SmsSenderFactory,
+)
+
+from tests.test_two_factor import tf_in_session
+from tests.test_webauthn import HackWebauthnUtil, wan_signin, setup_tf, reg_2_keys
+
+pytest.importorskip("webauthn")
+
+
+SmsSenderFactory.senders["test"] = SmsTestSender
+
+
+@pytest.mark.webauthn()
+@pytest.mark.two_factor()
+@pytest.mark.settings(webauthn_util_cls=HackWebauthnUtil)
+def test_tf_select(app, client, get_message):
+    # Test basic select mechanism when more than one 2FA has been setup
+    wankeys = reg_2_keys(client)  # add a webauthn 2FA key (authenticates)
+    sms_sender = setup_tf(client)
+    logout(client)
+
+    # since we have 2 2FA methods configured - we should get the tf-select form
+    response = client.post(
+        "/login",
+        data=dict(email="matt@lp.com", password="password"),
+        follow_redirects=True,
+    )
+    assert b"Select Two Factor Method" in response.data
+    response = client.post(
+        "/tf-select", data=dict(which="webauthn"), follow_redirects=True
+    )
+    assert b"Use Your WebAuthn Security Key as a Second Factor" in response.data
+
+    response = wan_signin(client, "matt@lp.com", wankeys["secondary"]["signin"])
+    assert not tf_in_session(get_session(response))
+
+    # verify actually logged in
+    response = client.get("/profile", follow_redirects=False)
+    assert response.status_code == 200
+
+    # now do other 2FA
+    logout(client)
+    response = client.post(
+        "/login",
+        data=dict(email="matt@lp.com", password="password"),
+        follow_redirects=True,
+    )
+    assert b"Select Two Factor Method" in response.data
+    response = client.post("/tf-select", data=dict(which="sms"), follow_redirects=True)
+    assert b"Please enter your authentication code generated via: sms" in response.data
+    code = sms_sender.messages[0].split()[-1]
+    response = client.post("/tf-validate", data=dict(code=code), follow_redirects=True)
+    assert b"Your token has been confirmed" in response.data
+
+    assert not tf_in_session(get_session(response))
+
+    # verify actually logged in
+    response = client.get("/profile", follow_redirects=False)
+    assert response.status_code == 200
+    assert not tf_in_session(get_existing_session(client))
+
+
+@pytest.mark.webauthn()
+@pytest.mark.two_factor()
+@pytest.mark.settings(webauthn_util_cls=HackWebauthnUtil)
+def test_tf_select_json(app, client, get_message):
+    # Test basic select mechanism when more than one 2FA has been setup
+    wankeys = reg_2_keys(client)  # add a webauthn 2FA key (authenticates)
+    setup_tf(client)
+    logout(client)
+
+    # since we have 2 2FA methods configured - we should get the tf-select form
+    response = client.post(
+        "/login", json=dict(email="matt@lp.com", password="password")
+    )
+    assert response.json["response"]["tf_required"]
+    choices = response.json["response"]["tf_setup_methods"]
+    assert all(k in choices for k in ["sms", "webauthn"])
+
+    # use webauthn as the second factor
+    response = client.post("/tf-select", json=dict(which="webauthn"))
+    signin_url = response.json["response"]["tf_signin_url"]
+    headers = {"Accept": "application/json", "Content-Type": "application/json"}
+    response = client.post(signin_url, headers=headers)
+    response_url = f'wan-signin/{response.json["response"]["wan_state"]}'
+    response = client.post(
+        response_url,
+        json=dict(credential=json.dumps(wankeys["secondary"]["signin"])),
+    )
+    assert response.status_code == 200
+    assert not tf_in_session(get_existing_session(client))
+
+    response = client.get("/profile", follow_redirects=False)
+    assert response.status_code == 200
+
+
+@pytest.mark.two_factor()
+def test_tf_select_auth(app, client, get_message):
+    # /tf-select is an unauthenticated endpoint - make sure only allowable in correct
+    # state.
+    response = client.get("/tf-select", follow_redirects=False)
+    assert response.location == "http://localhost/login"

--- a/tests/test_two_factor.py
+++ b/tests/test_two_factor.py
@@ -4,7 +4,7 @@
 
     two_factor tests
 
-    :copyright: (c) 2019-2021 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2019-2022 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 """
 
@@ -78,6 +78,7 @@ def tf_in_session(session):
             "tf_user_id",
             "tf_remember_login",
             "tf_totp_secret",
+            "tf_select",
         ]
     )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -94,6 +94,16 @@ def get_session(response):
                 return val[1]
 
 
+def get_existing_session(client):
+    cookie = next(
+        (cookie for cookie in client.cookie_jar if cookie.name == "session"), None
+    )
+    if cookie:
+        serializer = URLSafeTimedSerializer("secret", serializer=TaggedJSONSerializer())
+        val = serializer.loads_unsafe(cookie.value)
+        return val[1]
+
+
 def reset_fresh(client, within):
     # Assumes client authenticated.
     # Upon return the NEXT request if protected with a freshness check


### PR DESCRIPTION
* Twofactor re-factor into a plugin architecture.

* Introduce a two-factor plugin framework.

Now that we have 2 different two factor implementations (code and webauthn) there was a lot of duplicate code and lots of
changes to 2FA independent code to shoehorn in the new one (webauthn). With a request to add Duo 2FA it became clear that we really needed
to abstract out the common code.

Also - this provided the obvious place to put in a tf-select endpoint - used when a user has setup more than one 2FA mechanism - they have to choose which to use!

A couple other small changes:
- add simple_render_json - for endpoints that aren't returning any form data - just creates a CSRF token and returns.
- add get_form_field_xlate - make a lazy string for arbitrary text - need to use this in unified signin etc - which really aren't correctly localizable.